### PR TITLE
conf: Integration of "sphinxcontrib-bibtex" is not needed

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -26,7 +26,6 @@ myst_enable_extensions = [
     "amsmath",
     "dollarmath", # support latex equation inside $ $
     "linkify", # convert bare links to hyperlinks
-    "sphinxcontrib.bibtex",
 ]
 myst_heading_anchors = 7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ myst-parser[linkify]
 pygments
 sphinx
 sphinx-book-theme
-sphinxcontrib-bibtex


### PR DESCRIPTION
The extension is not needed to render "bibtex" code block. This commit partially reverts b52cc18 (Add "Citing" section to README and Book landing page)

Note also that "sphinxcontrib.bibtex" was incorrectly added to "myst_enable_extensions", it should have been added to the "extensions" list.