### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"  # Last stable CPython version
+
+sphinx:
+   configuration: conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+python:
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
All options are applied to the version containing this file.

See https://docs.readthedocs.io/en/stable/config-file/v2.html for details