### PR TITLE
Add pre-commit workflow running the "reuse" hook & Add missing SPDX tags to files

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright 2023 VTK Book Authors and Contributor
+# SPDX-License-Identifier: Apache-2.0
+
+name: pre-commit
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+    - uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
+      with:
+        python-version: '3.11'
+
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright 2023 VTK Book Authors and Contributor
+# SPDX-License-Identifier: Apache-2.0
+
+repos:
+- repo: https://github.com/fsfe/reuse-tool
+  rev: "v1.1.2"
+  hooks:
+  - id: reuse

--- a/VTKBook/Figures/Equations.txt
+++ b/VTKBook/Figures/Equations.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2016 VTK Book Authors and Contributors
+# SPDX-License-Identifier: CC-BY-4.0
+
 Chapter 4
 % Equation 4-1
 

--- a/VTKBook/Figures/FigureTemplates.txt
+++ b/VTKBook/Figures/FigureTemplates.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright 2016 VTK Book Authors and Contributors
+# SPDX-License-Identifier: CC-BY-4.0
+
 Code to hide vtk objects in Figures
 &#118;
 

--- a/VTKBook/Figures/README.md
+++ b/VTKBook/Figures/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-FileCopyrightText: Copyright 2016 VTK Book Authors and Contributors -->
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # Where are the figures ?
 
 Figures are stored in https://github.com/Kitware/vtk-book under releases section:

--- a/index.md
+++ b/index.md
@@ -1,3 +1,5 @@
+<!-- SPDX-FileCopyrightText: Copyright 2016 VTK Book Authors and Contributors -->
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
 # VTK Book
 
 We are pleased to provide an update on efforts to update the online

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright 2023 VTK Book Authors and Contributors
+# SPDX-License-Identifier: Apache-2.0
 myst-parser[linkify]
 pygments
 sphinx


### PR DESCRIPTION
This commit adds GitHub workflow for running the `reuse` linter [^1] and report issue if there are missing `SPDX` tags.

[^1]: https://github.com/fsfe/reuse-tool/tree/main#run-as-pre-commit-hook

### Expected output prior adding missing tags

```
$ reuse lint
# MISSING COPYRIGHT AND LICENSING INFORMATION

The following files have no copyright and licensing information:
* VTKBook/Figures/Equations.txt
* VTKBook/Figures/FigureTemplates.txt
* VTKBook/Figures/README.md
* index.md
* requirements.txt


# SUMMARY

* Bad licenses:
* Deprecated licenses:
* Licenses without file extension:
* Missing licenses:
* Unused licenses:
* Used licenses: Apache-2.0, CC-BY-4.0
* Read errors: 0
* Files with copyright information: 23 / 28
* Files with license information: 23 / 28

Unfortunately, your project is not compliant with version 3.0 of the REUSE Specification :-(
```

### After

After adding the missing SPDX tags:

```
$ reuse lint
# SUMMARY

* Bad licenses:
* Deprecated licenses:
* Licenses without file extension:
* Missing licenses:
* Unused licenses:
* Used licenses: Apache-2.0, CC-BY-4.0
* Read errors: 0
* Files with copyright information: 28 / 28
* Files with license information: 28 / 28

Congratulations! Your project is compliant with version 3.0 of the REUSE Specification :-)
```