### PR TITLE
Add settings that used to be automatically injected by RTD

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -18,6 +18,17 @@ author = "VTK Book Authors and Contributors"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
+
+# Define the canonical URL if you are using a custom domain on Read the Docs
+import os
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.


### PR DESCRIPTION
Following the advice in [1], add code to the configuration file that readthedocs used to inject automatically but will no longer.

[1] https://about.readthedocs.com/blog/2024/07/addons-by-default/